### PR TITLE
Fix updateShelf validation

### DIFF
--- a/src/service/shelf.service.ts
+++ b/src/service/shelf.service.ts
@@ -32,8 +32,8 @@ class ShelfService {
 
     updateShelf = async (id: string, shelf: UpdateShelfDto) => {
         const currentShelf = await this.shelfRepository.find({ id }, ['books']);
-        if (currentShelf.books.length > 0) {
-            throw new HttpException(400, 'Bad Request', ['Shelf has books']);
+        if (currentShelf.code === shelf.code && currentShelf.location === shelf.location) {
+            throw new HttpException(400, 'Bad Request', ['No changes made']);
         }
         const newshelf = new Shelf();
         newshelf.code = shelf.code;


### PR DESCRIPTION
This pull request fixes the validation logic in the updateShelf method of the ShelfService class. Previously, the validation was checking if the current shelf had books, but it should actually check if there are any changes made to the shelf code and location. This PR updates the validation to correctly throw a 400 Bad Request error when no changes are made to the shelf.